### PR TITLE
Add "-parameters" to compiler args

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This parameter needs to be set in order for ACF to generate named syntax messages, as per [Maven Setup](https://github.com/aikar/commands/wiki/Maven-Setup).

This should be added to all other sub-plugins and probably to the core as well, in order to fix this issue:
![image](https://user-images.githubusercontent.com/12859334/81621865-d9470b00-93ef-11ea-8111-45becb4e468d.png)

_(I'm actually surprised nobody has reported this yet)_